### PR TITLE
File based options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ const handler = new CommandHandler(
   new TCommand(),
   new FileOptionsProvider<T>(
     /\.t\.yml$/,
-    new YamlParser(), // or `new JSONParser()`
+    new YamlFormatParser(), // or `new JSONFormatParser()`
     new TOptionsValidator()
   )
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # 0.0.1
 
+### File Options
+Sometimes a `Command<T>` can get its `T` from a config file. We now have a
+`FileOptionsProvider<T>` that can help with that:
+
+```typescript
+interface T {
+  option: string
+  flag: boolean
+}
+
+class TCommand implements Command<T> {
+  execute (t: T) {
+    // Do something with `t`
+  }
+}
+
+class TOptionsValidator implements OptionsValidator<T> {
+  validate (input: any): Partial<T> {
+    if (typeof input !== 'object') {
+      throw new Error('Input must be an object')
+    }
+
+    const t = {}
+    if (typeof input.option === 'string') {
+      t.option = input.option
+    }
+    if (typeof input.flag === 'boolean') {
+      t.flag = input.flag
+    }
+    return t
+  }
+}
+
+const handler = new CommandHandler(
+  new TCommand(),
+  new FileOptionsProvider<T>(
+    /\.t\.yml$/,
+    new YamlParser(), // or `new JSONParser()`
+    new TOptionsValidator()
+  )
+)
+```
+
 ### Argv
 A `Command<T>` needs a way to receive a `T` from command line arguments. To do that, an
 implementation of the `OptionsProvider<T>` called `ArgvOptionsProvider<T>` is available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ const handler = new CommandHandler(
   new TCommand(),
   new FileOptionsProvider<T>(
     /\.t\.yml$/,
-    new YamlFormatParser(), // or `new JSONFormatParser()`
+    new YamlFormatParser(), // or `new JsonFormatParser()`
     new TOptionsValidator()
   )
 )

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ const optionsProviders: OptionsProvider<GreetOptions>[] = [
   // extract some options from a YAML config file.
   new FileOptionsProvider<GreetOptions>(
     /^\.greet\.yml$/,
-    new YamlParser(), // A JsonParser is also available!
+    new YamlFormatParser(), // A JsonFormatParser is also available!
     new GreetPartialValidator()
   ),
 

--- a/__tests__/FileOptions/FileOptionsProvider.test.ts
+++ b/__tests__/FileOptions/FileOptionsProvider.test.ts
@@ -22,17 +22,20 @@ describe('FileOptionsProvider', () => {
       new OptsValidator()
     )
 
-    const testfile = '{"option":"value"}'
+    const testfile = {
+      content: '{"option":"value"}',
+      path: { absolute: 'testfile', isFile: true }
+    }
 
     const opts = await provider.provide({
       filesystem: {
         async findFirstUpward (pat: string | RegExp) {
           expect(pat).toEqual(/testfile$/)
-          return 'testfile'
+          return testfile.path
         },
         async readFile (path: any) {
-          expect(path).toEqual('testfile')
-          return testfile
+          expect(path).toEqual(testfile.path)
+          return testfile.content
         }
       } as any
     })

--- a/__tests__/FileOptions/FileOptionsProvider.test.ts
+++ b/__tests__/FileOptions/FileOptionsProvider.test.ts
@@ -1,0 +1,5 @@
+describe('FileOptionsProvider', () => {
+  it('reads options from a file', () => {
+    // WIP
+  })
+})

--- a/__tests__/FileOptions/FileOptionsProvider.test.ts
+++ b/__tests__/FileOptions/FileOptionsProvider.test.ts
@@ -1,5 +1,44 @@
+import {FileOptionsProvider} from '../../src/FileOptions/FileOptionsProvider'
+import {Validator} from '../../src/FileOptions/Validator'
+import {JsonFormatParser} from '../../src/FileOptions/JsonFormatParser'
+
 describe('FileOptionsProvider', () => {
-  it('reads options from a file', () => {
-    // WIP
+  it('reads options from a file', async () => {
+    interface Opts {
+      option: string
+    }
+
+    class OptsValidator implements Validator<Opts> {
+      validate (input: any): Opts {
+        return {
+          option: input.option
+        }
+      }
+    }
+
+    const provider = new FileOptionsProvider<Opts>(
+      /testfile$/,
+      new JsonFormatParser(),
+      new OptsValidator()
+    )
+
+    const testfile = '{"option":"value"}'
+
+    const opts = await provider.provide({
+      filesystem: {
+        async findFirstUpward (pat: string | RegExp) {
+          expect(pat).toEqual(/testfile$/)
+          return 'testfile'
+        },
+        async readFile (path: any) {
+          expect(path).toEqual('testfile')
+          return testfile
+        }
+      } as any
+    })
+
+    expect(opts).toEqual({
+      option: 'value'
+    })
   })
 })

--- a/__tests__/FileOptions/JsonFormatParser.test.ts
+++ b/__tests__/FileOptions/JsonFormatParser.test.ts
@@ -1,0 +1,13 @@
+import {JsonFormatParser} from '../../src/FileOptions/JsonFormatParser'
+
+describe('JsonFormatParser', () => {
+  const parser = new JsonFormatParser()
+
+  it('parses JSON', () => {
+    const res = parser.parse('{"option":"value"}')
+
+    expect(res).toEqual({
+      option: 'value'
+    })
+  })
+})

--- a/__tests__/FileOptions/YamlFormatParser.test.ts
+++ b/__tests__/FileOptions/YamlFormatParser.test.ts
@@ -1,0 +1,13 @@
+import {YamlFormatParser} from '../../src/FileOptions/YamlFormatParser'
+
+describe('YamlFormatParser', () => {
+  const parser = new YamlFormatParser()
+
+  it('parses YAML', () => {
+    const res = parser.parse('option: value')
+
+    expect(res).toEqual({
+      option: 'value'
+    })
+  })
+})

--- a/__tests__/Node/NodeFileSystem.test.ts
+++ b/__tests__/Node/NodeFileSystem.test.ts
@@ -1,0 +1,74 @@
+import {NodeFileSystem} from '../../src/Node/NodeFileSystem'
+import {NodePath} from '../../src/Node/NodePath'
+import {FilePath} from '../../src/FileSystem/Path'
+
+describe('NodeFileSystem', () => {
+  const fs = new NodeFileSystem(new NodePath('/one/two/three', true), {
+    readdir (path: string, callback: (err: Error | null, files: string[]) => void) {
+      switch (path) {
+        case '/one/two/three':
+          return callback(null, ['x.true', 'y.false', 'z.true'])
+        case '/one/two':
+          return callback(null, ['a.false', 'b.true'])
+        case '/one':
+          return callback(null, [])
+        case '/':
+          return callback(null, ['b.true'])
+        default:
+          return callback(new Error(`No such directory: ${path}`), [])
+      }
+    },
+
+    stat (path: string, callback: (err: Error | null, stats: {
+      isFile(): boolean
+      isDirectory(): boolean
+    }) => any): void {
+      if (path.indexOf('.') !== -1) {
+        return callback(null, {
+          isFile: () => true,
+          isDirectory: () => false
+        })
+      }
+      callback(null, {
+        isFile: () => false,
+        isDirectory: () => true
+      })
+    },
+
+    readFile (
+      filename: string,
+      callback: (err: Error | null, data: { toString (): string }) => void
+    ): void {
+      callback(null, `Content of ${filename}`)
+    }
+  })
+
+  it('can find all files matching the given pattern in ancestor directories', async () => {
+    const paths = await fs.findUpward(/\.true$/)
+
+    expect(paths).toEqual([
+      new NodePath('/one/two/three/x.true', false),
+      new NodePath('/one/two/three/z.true', false),
+      new NodePath('/one/two/b.true', false),
+      new NodePath('/b.true', false)
+    ])
+  })
+
+  it('can find the first file matching the given pattern in ancestor directories', async () => {
+    expect(
+      await fs.findFirstUpward(/a\.false$/)
+    ).toEqual(
+      new NodePath('/one/two/a.false', false)
+    )
+  })
+
+  it('can read a file', async () => {
+    expect(
+      await fs.readFile(
+        await fs.findFirstUpward(/a\.false$/) as FilePath
+      )
+    ).toEqual(
+      'Content of /one/two/a.false'
+    )
+  })
+})

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "typescript": "^2.1.5"
   },
   "dependencies": {
-    "tslib": "^1.5.0"
+    "@types/yamljs": "^0.2.30",
+    "tslib": "^1.5.0",
+    "yamljs": "^0.2.8"
   },
   "jest": {
     "transform": {

--- a/src/FileOptions/FileOptionsProvider.ts
+++ b/src/FileOptions/FileOptionsProvider.ts
@@ -1,6 +1,7 @@
 import {Validator} from './Validator'
 import {FormatParser} from './FormatParser'
 import {OptionsProvider} from '../Options/OptionsProvider'
+import {Path, FilePath} from '../FileSystem/Path'
 import {Kernel} from '../Kernel'
 import {Partial} from '../Util/Partial'
 
@@ -18,7 +19,7 @@ export class FileOptionsProvider <T> implements OptionsProvider<T> {
 
     const path = await filesystem.findFirstUpward(this.pattern)
 
-    if (path == null) {
+    if (path == null || !(this._isFile(path))) {
       return {} as any
     }
 
@@ -27,5 +28,9 @@ export class FileOptionsProvider <T> implements OptionsProvider<T> {
     const validated = this.validator.validate(decoded)
 
     return validated
+  }
+
+  _isFile (path: Path): path is FilePath {
+    return path.isFile
   }
 }

--- a/src/FileOptions/FileOptionsProvider.ts
+++ b/src/FileOptions/FileOptionsProvider.ts
@@ -1,0 +1,31 @@
+import {Validator} from './Validator'
+import {FormatParser} from './FormatParser'
+import {OptionsProvider} from '../Options/OptionsProvider'
+import {Kernel} from '../Kernel'
+import {Partial} from '../Util/Partial'
+
+export class FileOptionsProvider <T> implements OptionsProvider<T> {
+  constructor (
+    public readonly pattern: RegExp | string,
+    public readonly parser: FormatParser,
+    public readonly validator: Validator<T>
+  ) {}
+
+  async provide ({ filesystem }: Kernel): Promise<Partial<T>> {
+    if (filesystem == null) {
+      return {} as any
+    }
+
+    const path = await filesystem.findFirstUpward(this.pattern)
+
+    if (path == null) {
+      return {} as any
+    }
+
+    const encoded = await filesystem.readFile(path)
+    const decoded = this.parser.parse(encoded)
+    const validated = this.validator.validate(decoded)
+
+    return validated
+  }
+}

--- a/src/FileOptions/FormatParser.ts
+++ b/src/FileOptions/FormatParser.ts
@@ -1,0 +1,3 @@
+export interface FormatParser {
+  parse (encoded: string): any
+}

--- a/src/FileOptions/JsonFormatParser.ts
+++ b/src/FileOptions/JsonFormatParser.ts
@@ -1,0 +1,7 @@
+import {FormatParser} from './FormatParser'
+
+export class JsonFormatParser implements FormatParser {
+  parse (json: string): any {
+    return JSON.parse(json)
+  }
+}

--- a/src/FileOptions/Validator.ts
+++ b/src/FileOptions/Validator.ts
@@ -1,0 +1,5 @@
+import {Partial} from '../Util/Partial'
+
+export interface Validator <T> {
+  validate (input: any): Partial<T>
+}

--- a/src/FileOptions/YamlFormatParser.ts
+++ b/src/FileOptions/YamlFormatParser.ts
@@ -1,0 +1,8 @@
+import {FormatParser} from './FormatParser'
+import {parse} from 'yamljs'
+
+export class YamlFormatParser implements FormatParser {
+  parse (yaml: string): any {
+    return parse(yaml)
+  }
+}

--- a/src/FileSystem/FileSystem.ts
+++ b/src/FileSystem/FileSystem.ts
@@ -1,7 +1,9 @@
-import {Path} from './Path'
+import {Path, DirectoryPath, FilePath} from './Path'
 
 export interface FileSystem {
+  cwd: DirectoryPath
+  list (directory: DirectoryPath): Promise<Path[]>
   findUpward (pattern: RegExp | string): Promise<Path[]>
   findFirstUpward (pattern: RegExp | string): Promise<Path | null>
-  readFile (path: Path): Promise<string>
+  readFile (path: FilePath): Promise<string>
 }

--- a/src/FileSystem/FileSystem.ts
+++ b/src/FileSystem/FileSystem.ts
@@ -1,0 +1,7 @@
+import {Path} from './Path'
+
+export interface FileSystem {
+  findUpward (pattern: RegExp | string): Promise<Path[]>
+  findFirstUpward (pattern: RegExp | string): Promise<Path | null>
+  readFile (path: Path): Promise<string>
+}

--- a/src/FileSystem/Path.ts
+++ b/src/FileSystem/Path.ts
@@ -1,1 +1,18 @@
-export interface Path {}
+export interface Path {
+  readonly absolute: string
+  readonly isRoot: boolean
+  readonly parent: DirectoryPath
+
+  readonly isDirectory: boolean
+  readonly isFile: boolean
+}
+
+export interface DirectoryPath extends Path {
+  readonly isDirectory: true
+  readonly isFile: false
+}
+
+export interface FilePath extends Path {
+  readonly isDirectory: false
+  readonly isFile: true
+}

--- a/src/FileSystem/Path.ts
+++ b/src/FileSystem/Path.ts
@@ -1,0 +1,1 @@
+export interface Path {}

--- a/src/Kernel.ts
+++ b/src/Kernel.ts
@@ -1,3 +1,6 @@
+import {FileSystem} from './FileSystem/FileSystem'
+
 export interface Kernel {
   readonly argv?: string[]
+  readonly filesystem?: FileSystem
 }

--- a/src/Kernel.ts
+++ b/src/Kernel.ts
@@ -1,6 +1,8 @@
 import {FileSystem} from './FileSystem/FileSystem'
+import {Path} from './FileSystem/Path'
 
 export interface Kernel {
   readonly argv?: string[]
+  readonly cwd?: Path
   readonly filesystem?: FileSystem
 }

--- a/src/Node/NodeFileSystem.ts
+++ b/src/Node/NodeFileSystem.ts
@@ -1,0 +1,118 @@
+import {FileSystem} from '../FileSystem/FileSystem'
+import {Path, DirectoryPath, FilePath} from '../FileSystem/Path'
+import {NodePath} from './NodePath'
+import * as fs from 'fs'
+import * as path from 'path'
+
+export interface NativeFileSystem {
+  readdir (path: string, callback: (err: Error | null, files: string[]) => void): void
+  stat (path: string, callback: (err: Error | null, stats: {
+    isFile(): boolean
+    isDirectory(): boolean
+  }) => any): void
+  readFile (
+    filename: string,
+    callback: (err: Error | null, data: { toString (): string }) => void
+  ): void
+}
+
+export interface NativePath {
+  resolve(...pathSegments: any[]): string
+}
+
+export class NodeFileSystem implements FileSystem {
+  constructor (
+    public readonly cwd: DirectoryPath,
+    private readonly _fs: NativeFileSystem = fs,
+    private readonly _path: NativePath = path
+  ) {
+    this._createPath = this._createPath.bind(this)
+  }
+
+  list (directory: DirectoryPath): Promise<Path[]> {
+    return new Promise((resolve, reject) => {
+      this._fs.readdir(directory.absolute, (err, files) => {
+        if (err != null) {
+          reject(err)
+        } else {
+          resolve(
+            Promise.all(
+              files
+                .map(p => this._path.resolve(directory.absolute, p))
+                .map(this._createPath)
+            )
+          )
+        }
+      })
+    })
+  }
+
+  findUpward (pattern: RegExp | string): Promise<Path[]> {
+    const regex = typeof pattern === 'string'
+      ? new RegExp(`^${pattern}$`)
+      : pattern
+
+    return this._findUpward([], this.cwd, regex)
+  }
+
+  async findFirstUpward (pattern: RegExp | string): Promise<Path | null> {
+    const regex = typeof pattern === 'string'
+      ? new RegExp(`^${pattern}$`)
+      : pattern
+
+    const matches = await this._findUpward([], this.cwd, regex, f => f.length > 0)
+
+    return matches[0] || null
+  }
+
+  readFile (path: FilePath): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this._fs.readFile(path.absolute, (err, buffer) => {
+        if (err != null) {
+          reject(err)
+        } else {
+          resolve(buffer.toString())
+        }
+      })
+    })
+  }
+
+  private _createPath (absolute: string): Promise<Path> {
+    return new Promise((resolve, reject) => {
+      this._fs.stat(absolute, (err, stat) => {
+        if (err != null) {
+          reject(err)
+        } else {
+          resolve(new NodePath(absolute, stat.isDirectory()))
+        }
+      })
+    })
+  }
+
+  async _findUpward (
+    carry: Path[],
+    dir: DirectoryPath,
+    pattern: RegExp,
+    shouldCancel: (found: Path[]) => boolean = () => false
+  ): Promise<Path[]> {
+    const paths = await this.list(dir)
+
+    let out = carry.concat(
+        paths.reduce(
+          (matching, path) => {
+            if (pattern.test(path.absolute)) {
+              return matching.concat(path)
+            }
+            return matching
+          },
+          [] as Path[]
+      )
+    )
+
+    if (dir.isRoot || shouldCancel(out)) {
+      return out
+    }
+
+    return this._findUpward(out, dir.parent, pattern)
+  }
+}

--- a/src/Node/NodeKernel.ts
+++ b/src/Node/NodeKernel.ts
@@ -1,8 +1,9 @@
 import {Kernel} from '../Kernel'
 import {NodeFileSystem} from './NodeFileSystem'
 import {NodePath} from './NodePath'
+import {DirectoryPath} from '../FileSystem/Path'
 
-const cwd = new NodePath(process.cwd(), true)
+const cwd: DirectoryPath = new NodePath(process.cwd(), true)
 
 export class NodeKernel implements Kernel {
   readonly argv = process.argv.slice(2)

--- a/src/Node/NodeKernel.ts
+++ b/src/Node/NodeKernel.ts
@@ -1,5 +1,11 @@
 import {Kernel} from '../Kernel'
+import {NodeFileSystem} from './NodeFileSystem'
+import {NodePath} from './NodePath'
+
+const cwd = new NodePath(process.cwd(), true)
 
 export class NodeKernel implements Kernel {
   readonly argv = process.argv.slice(2)
+  readonly cwd = cwd
+  readonly filesystem = new NodeFileSystem(cwd)
 }

--- a/src/Node/NodePath.ts
+++ b/src/Node/NodePath.ts
@@ -1,0 +1,32 @@
+import {Path, DirectoryPath, FilePath} from '../FileSystem/Path'
+import * as path from 'path'
+
+interface NodePath {
+  new (absolute: string, isDirectory: true): DirectoryPath
+  new (absolute: string, isDirectory: false): FilePath
+  new (absolute: string, isDirectory: boolean): Path
+}
+
+class NodePathClass implements Path {
+  public readonly isFile: boolean
+
+  constructor (
+    public readonly absolute: string,
+    public readonly isDirectory: boolean
+  ) {
+    this.isFile = !isDirectory
+  }
+
+  get isRoot (): boolean {
+    return this.parent.absolute === this.absolute
+  }
+
+  get parent (): DirectoryPath {
+    return new NodePath(
+      path.dirname(this.absolute),
+      true
+    ) as DirectoryPath
+  }
+}
+
+export const NodePath: NodePath = NodePathClass as any

--- a/src/Node/NodePath.ts
+++ b/src/Node/NodePath.ts
@@ -1,7 +1,7 @@
 import {Path, DirectoryPath, FilePath} from '../FileSystem/Path'
 import * as path from 'path'
 
-interface NodePath {
+export interface NodePath {
   new (absolute: string, isDirectory: true): DirectoryPath
   new (absolute: string, isDirectory: false): FilePath
   new (absolute: string, isDirectory: boolean): Path

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,10 @@
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.5.tgz#96a0f0a618b7b606f1ec547403c00650210bfbb7"
 
+"@types/yamljs@^0.2.30":
+  version "0.2.30"
+  resolved "https://registry.yarnpkg.com/@types/yamljs/-/yamljs-0.2.30.tgz#d034e1d329e46e8d0f737c9a8db97f68f81b5382"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -2698,6 +2702,13 @@ xml-name-validator@^2.0.1:
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+
+yamljs@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.2.8.tgz#ef23fb006e62f6ae07b406aa2a949561f336ea5c"
+  dependencies:
+    argparse "^1.0.7"
+    glob "^7.0.5"
 
 yargs-parser@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
- [x] Add `YamlFormatParser`
- [x] Add `JsonFormatParser`
- [x] Add ability to get command options from a file:

```yaml
# .t.yml
option: value
flag: true
```

```typescript
interface T {
  option: string
  flag: boolean
}

class TCommand implements Command<T> {
  execute (t: T) {
    // Do something with `t`
  }
}

class TOptionsValidator implements OptionsValidator<T> {
  validate (input: any): Partial<T> {
    if (typeof input !== 'object') {
      throw new Error('Input must be an object')
    }

    const t = {}
    if (typeof input.option === 'string') {
      t.option = input.option
    }
    if (typeof input.flag === 'boolean') {
      t.flag = input.flag
    }
    return t
  }
}

const handler = new CommandHandler(
  new TCommand(),
  new FileOptionsProvider<T>(
    /\.t\.yml$/,
    new YamlFormatParser(), // or `new JsonFormatParser()`
    new TOptionsValidator()
  )
)
```